### PR TITLE
Add Configurable Emote Distance

### DIFF
--- a/core/src/main/java/dev/geco/gsit/manager/CManager.java
+++ b/core/src/main/java/dev/geco/gsit/manager/CManager.java
@@ -79,6 +79,8 @@ public class CManager {
 
     public boolean C_DOUBLE_SNEAK;
 
+    public double GEMOTE_MAX_DISTANCE;
+
 
     public boolean TRUSTED_REGION_ONLY;
 
@@ -194,6 +196,8 @@ public class CManager {
         COMMANDBLACKLIST = GPM.getConfig().getStringList("Options.CommandBlacklist");
 
         FEATUREFLAGS = GPM.getConfig().getStringList("FeatureFlags");
+		
+		GEMOTE_MAX_DISTANCE = GPM.getConfig().getDouble("Options.GEmote.max-distance");
     }
 
 }

--- a/core/src/main/java/dev/geco/gsit/objects/GEmote.java
+++ b/core/src/main/java/dev/geco/gsit/objects/GEmote.java
@@ -22,7 +22,7 @@ public class GEmote {
 
     protected HashMap<Entity, BukkitRunnable> tasks = new HashMap<>();
 
-    protected long range = 250;
+    protected long range = (long) GSitMain.getInstance().getCManager().GEMOTE_MAX_DISTANCE;
 
     public GEmote(String Id, List<GEmotePart> Parts, long Loop, boolean Head) {
 

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -121,6 +121,12 @@ Options:
 
     # Defines whether a player can double-sneak in a short amount of time to start crawling
     double-sneak: false
+    
+    
+  GEmote:
+    
+    #Defines maximum range emotes can be seen from. Default 250
+    max-distance: 250
 
 
 


### PR DESCRIPTION
Added GEmote visibility distance to the config.yml to replace the hard-coded 250 block distance currently used