### PR TITLE
Make GSit easy to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,11 @@ Clone the repository:
 git clone https://github.com/Gecolay/GSit.git
 ```
 
-### Spigot BuildTools
-
-Install all the [BuildTools](https://www.spigotmc.org/wiki/buildtools/) versions (with the "--remapped" parameter):
-
-- [1.17](https://www.spigotmc.org/wiki/buildtools/#1-17)
-- [1.17.1](https://www.spigotmc.org/wiki/buildtools/#1-17-1)
-- [1.18.1](https://www.spigotmc.org/wiki/buildtools/#1-18-1)
-- [1.18.2](https://www.spigotmc.org/wiki/buildtools/#1-18-2)
-- [1.19](https://www.spigotmc.org/wiki/buildtools/#1-19)
-- [1.19.2](https://www.spigotmc.org/wiki/buildtools/#1-19-2)
-- [1.19.3](https://www.spigotmc.org/wiki/buildtools/#1-19-3)
-- [1.19.4](https://www.spigotmc.org/wiki/buildtools/#1-19-4)
-- [1.20.1](https://www.spigotmc.org/wiki/buildtools/#1-20-1)
-- [1.20.2](https://www.spigotmc.org/wiki/buildtools/#1-20-2)
-- [1.20.4](https://www.spigotmc.org/wiki/buildtools/#1-20-4)
-
 ### Build
 
 Run the maven build command by your ide or in a terminal.
+
+`mvn clean package`
 
 The final `GSit-x.x-x.jar` file will be in the [`target`](./target) folder.
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,13 @@
         <url>https://github.com/Gecolay/GSit/issues</url>
     </issueManagement>
 
+    <repositories>
+        <repository>
+            <id>codemc</id>
+            <url>https://repo.codemc.io/repository/nms/</url>
+        </repository>
+    </repositories>
+
     <modules>
         <module>core</module>
         <module>mcv1_17</module>


### PR DESCRIPTION
Use nms repo of CodeMC, so no need to take too much time to use BuildTools to build Spigot version by version. 