### PR TITLE
Fix #153

### DIFF
--- a/core/src/main/java/dev/geco/gsit/link/PlaceholderAPILink.java
+++ b/core/src/main/java/dev/geco/gsit/link/PlaceholderAPILink.java
@@ -35,6 +35,10 @@ public class PlaceholderAPILink extends PlaceholderExpansion {
     @Override
     public @NotNull List<String> getPlaceholders() { return Arrays.asList("crawling", "emoting", "playertoggle", "posing", "sitting", "toggle"); }
 
+    // https://wiki.placeholderapi.com/developers/creating-a-placeholderexpansion/#making-an-internal-expansion
+    @Override
+    public boolean persist() { return true; }
+    
     @Override
     public String onRequest(OfflinePlayer Player, @NotNull String Params) {
 


### PR DESCRIPTION
Close #153

PAPI will unregister all hooks where the method `persistent` doesn't return true on reload.