### PR TITLE
Prevent empty actionbar messages from being sent

### DIFF
--- a/core/src/main/java/dev/geco/gsit/manager/mm/MPaperManager.java
+++ b/core/src/main/java/dev/geco/gsit/manager/mm/MPaperManager.java
@@ -60,7 +60,7 @@ public class MPaperManager extends MManager {
 
     public void sendMessage(@NotNull CommandSender Target, String Message, Object... ReplaceList) { Target.sendMessage(getLanguageComponent(Message, getLanguage(Target), ReplaceList)); }
 
-    public void sendActionBarMessage(@NotNull Player Target, String Message, Object... ReplaceList) { Target.sendActionBar(getLanguageComponent(Message, getLanguage(Target), ReplaceList)); }
+    public void sendActionBarMessage(@NotNull Player Target, String Message, Object... ReplaceList) { if(!Message.trim().isEmpty()) Target.sendActionBar(getLanguageComponent(Message, getLanguage(Target), ReplaceList)); }
 
     private @NotNull Component getLanguageComponent(String Message, String LanguageCode, Object... ReplaceList) { return toFormattedComponent(getRawMessageByLanguage(Message, LanguageCode, ReplaceList)); }
 

--- a/core/src/main/java/dev/geco/gsit/manager/mm/MSpigotManager.java
+++ b/core/src/main/java/dev/geco/gsit/manager/mm/MSpigotManager.java
@@ -23,6 +23,6 @@ public class MSpigotManager extends MManager {
 
     public void sendMessage(@NotNull CommandSender Target, String Message, Object... ReplaceList) { Target.sendMessage(getMessageByLanguage(Message, getLanguage(Target), ReplaceList)); }
 
-    public void sendActionBarMessage(@NotNull Player Target, String Message, Object... ReplaceList) { if(allowBungeeMessages) Target.spigot().sendMessage(ChatMessageType.ACTION_BAR, net.md_5.bungee.api.chat.TextComponent.fromLegacyText(getMessageByLanguage(Message, getLanguage(Target), ReplaceList))); }
+    public void sendActionBarMessage(@NotNull Player Target, String Message, Object... ReplaceList) { if(allowBungeeMessages && !Message.trim().isEmpty()) Target.spigot().sendMessage(ChatMessageType.ACTION_BAR, net.md_5.bungee.api.chat.TextComponent.fromLegacyText(getMessageByLanguage(Message, getLanguage(Target), ReplaceList))); }
 
 }


### PR DESCRIPTION
This allows users to effectively disable actionbar messages by setting them to "" or " ".