### PR TITLE
Add configurable up-face block interaction check

### DIFF
--- a/core/src/main/java/dev/geco/gsit/events/InteractEvents.java
+++ b/core/src/main/java/dev/geco/gsit/events/InteractEvents.java
@@ -26,7 +26,7 @@ public class InteractEvents implements Listener {
         Action action = Event.getAction();
         if(Event.getHand() != EquipmentSlot.HAND || action != Action.RIGHT_CLICK_BLOCK) return;
 
-        if(Event.getBlockFace() != BlockFace.UP) return;
+        if(GPM.getCManager().S_UP_FACE_ONLY && Event.getBlockFace() != BlockFace.UP) return;
 
         if(GPM.getCManager().S_EMPTY_HAND_ONLY && Event.getItem() != null) return;
 

--- a/core/src/main/java/dev/geco/gsit/manager/CManager.java
+++ b/core/src/main/java/dev/geco/gsit/manager/CManager.java
@@ -27,6 +27,7 @@ public class CManager {
 
     public final HashMap<Material, Double> S_SITMATERIALS = new HashMap<>();
     public boolean S_BOTTOM_PART_ONLY;
+    public boolean S_UP_FACE_ONLY;
     public boolean S_EMPTY_HAND_ONLY;
     public double S_MAX_DISTANCE;
     public boolean S_DEFAULT_SIT_MODE;
@@ -116,6 +117,7 @@ public class CManager {
             } catch (Throwable ignored) { }
         }
         S_BOTTOM_PART_ONLY = GPM.getConfig().getBoolean("Options.Sit.bottom-part-only", true);
+        S_UP_FACE_ONLY = GPM.getConfig().getBoolean("Options.Sit.up-face-only", true);
         S_EMPTY_HAND_ONLY = GPM.getConfig().getBoolean("Options.Sit.empty-hand-only", true);
         S_MAX_DISTANCE = GPM.getConfig().getDouble("Options.Sit.max-distance", 0d);
         S_DEFAULT_SIT_MODE = GPM.getConfig().getBoolean("Options.Sit.default-sit-mode", true);

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -50,6 +50,9 @@ Options:
     # Allow sitting only on the bottom part of stairs and slabs
     bottom-part-only: true
 
+    # Allow sitting only when clicking on the top face of a block
+    up-face-only: true
+
     # Require an empty main hand to sit by clicking
     empty-hand-only: true
 


### PR DESCRIPTION
Added a new configuration option to control whether sitting is allowed only when clicking on the top face of blocks.

Changes:
- Added new configuration option `up-face-only` (default: true) in config.yml
- Modified InteractEvents to check the up-face-only setting before restricting block face interactions
- Added S_UP_FACE_ONLY field to CManager for configuration handling

Previously, sitting was only allowed when clicking on the top face of blocks. This change makes this behavior configurable, allowing server administrators to decide whether players can sit by clicking on any face of a block or only the top face.

The default setting (true) maintains the original behavior, ensuring backward compatibility.