### PR TITLE
Fix #236

### DIFF
--- a/core/src/main/java/dev/geco/gsit/service/SitService.java
+++ b/core/src/main/java/dev/geco/gsit/service/SitService.java
@@ -170,7 +170,7 @@ public class SitService {
             if(seat.getSeatEntity().isValid()) gSitMain.getEntityUtil().setEntityLocation(seat.getSeatEntity(), returnLocation);
             if(gSitMain.supportsFoliaFeature()) gSitMain.getTaskService().runDelayed(() -> {
                 if(entity.isValid()) gSitMain.getEntityUtil().setEntityLocation(entity, returnLocation);
-            }, entity, 0);
+            }, true, Bukkit.isOwnedByCurrentRegion(entity) ? entity : null, 0);
             else if(entity.isValid()) gSitMain.getEntityUtil().setEntityLocation(entity, returnLocation);
 
             entityBlocked.remove(entity.getUniqueId());


### PR DESCRIPTION
Fix #236

Changes:

Add checks whether the entity is in the current TickRegion.
If yes, use EntityScheduler (as before).
If not, use GlobalRegionScheduler to schedule the teleport safely.