### PR TITLE
Fixed incorrect removal of players after PlayerQuitEvent is triggered on Folia server

### DIFF
--- a/core/src/main/java/dev/geco/gsit/service/PlayerSitService.java
+++ b/core/src/main/java/dev/geco/gsit/service/PlayerSitService.java
@@ -88,8 +88,7 @@ public class PlayerSitService {
             for(UUID passenger : passengers.getValue()) {
                 Entity passengerEntity = Bukkit.getEntity(passenger);
                 if(passengerEntity == null) continue;
-                if(gSitMain.isFoliaServer()) gSitMain.getTaskService().run(passengerEntity::remove, passengerEntity);
-                else passengerEntity.remove();
+                passengerEntity.remove();
             }
             String key = source.getUniqueId().toString() + passengers.getKey();
             Long spawnTime = spawnTimes.get(key);
@@ -105,8 +104,7 @@ public class PlayerSitService {
             for(UUID vehicle : vehicles.getValue()) {
                 Entity vehicleEntity = Bukkit.getEntity(vehicle);
                 if(vehicleEntity == null) continue;
-                if(gSitMain.isFoliaServer()) gSitMain.getTaskService().run(vehicleEntity::remove, vehicleEntity);
-                else vehicleEntity.remove();
+                vehicleEntity.remove();
             }
             String key = vehicles.getKey().toString() + source.getUniqueId();
             Long spawnTime = spawnTimes.get(key);


### PR DESCRIPTION
Fixed incorrect removal of players after PlayerQuitEvent is triggered on Folia server

fix https://github.com/gecolay/GSit/issues/258