### PR TITLE
Fix: Add missing GSit.LayBack permission to plugin.yml

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -103,12 +103,17 @@ permissions:
     description: Pose | Permissions
     children:
       GSit.Lay: true
+      GSit.LayBack: true
       GSit.BellyFlop: true
       GSit.Spin: true
 
   GSit.Lay:
     default: true
     description: Lay command | Permission
+
+  GSit.LayBack:
+    default: true
+    description: Lay back | Permission
 
   GSit.BellyFlop:
     default: true


### PR DESCRIPTION
## Description

This PR fixes an issue where the `/glayback` command was defined, but its corresponding permission node, `GSit.LayBack`, was not registered in `plugin.yml`.

This prevented the permission from being assigned by default (`default: true`) or from being inherited correctly via the `GSit.Pose.*` parent node.

## Changes

* Added the `GSit.LayBack` permission definition under the `permissions:` section.
* Added `GSit.LayBack: true` as a child permission to `GSit.Pose.*`.

This ensures the permission for the `/glayback` command functions as intended.